### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "clang++-7 -pthread -o main main.cpp && ./main"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # C-Templated-Input-Validation-Testing
 Testing different ways to validate input using templates, concepts, and lambdas
+
+[![Run on Repl.it](https://repl.it/badge/github/willowell/C-Templated-Input-Validation-Testing)](https://repl.it/github/willowell/C-Templated-Input-Validation-Testing)
+
+[View Original on Repl.it](https://repl.it/@willowell/C-Templated-Input-Validation-Testing)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@willowell/C-Templated-Input-Validation-Testing).